### PR TITLE
Implement additive relationship matrix

### DIFF
--- a/tests/test_kinship.py
+++ b/tests/test_kinship.py
@@ -1,5 +1,5 @@
 import numpy as np
-from src.kinship import make_inbreeding_fn
+from src.kinship import make_inbreeding_fn, build_additive_matrix
 from .fixtures import pedigree
 
 
@@ -11,3 +11,11 @@ def test_wright_relationship():
     assert np.isclose(R("P1", "P2"), 0.25)
     # внуки общ. предка через разных полусибсов: R = 0.0625
     assert np.isclose(R("A", "B"), 0.0625)
+
+
+def test_additive_matrix():
+    A = build_additive_matrix(pedigree)
+    assert np.isclose(A.loc["P1", "P2"], 0.25)
+    assert np.isclose(A.loc["A", "B"], 0.0625)
+    # диагональ = 1 + F; для базовых животных F=0
+    assert np.isclose(A.loc["G1", "G1"], 1.0)


### PR DESCRIPTION
## Summary
- implement tabular method to build additive relationship matrix
- allow `build_feasible_pairs` to accept a precomputed matrix
- test additive matrix computation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864fd55d160832fb2a969523866dfcd